### PR TITLE
Wireshark module will no longer compile (API change?)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ firmware/packages/
 firmware/platforms/
 
 firmware/appstate.json
+dissectors/h4bcm.so
+host_stack/libbtstack.so
+host_stack/sdp_rfcomm_query
+host_stack/spp_counter

--- a/dissectors/packet-btbrlmp.c
+++ b/dissectors/packet-btbrlmp.c
@@ -3731,7 +3731,7 @@ void dissect_ping_res(proto_tree *tree, tvbuff_t *tvb, int offset, int len)
 
 /* Link Manager Protocol */
 static int
-dissect_btbrlmp(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
+dissect_btbrlmp(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *foo) // Dummy parameter required by new Wireshark API
 {
 	proto_item *lmp_item;
 	proto_tree *lmp_tree;


### PR DESCRIPTION
I came across your project and was interested to learn more, but disappointed when compilation errors resulted from the build script.

packet-btbrlmp.c:4965:30: error: incompatible function pointer types passing 'int (tvbuff_t *, packet_info *, proto_tree *)' (aka 'int (struct tvbuff *, struct _packet_info *, struct _proto_node *)') to parameter of type 'dissector_t' (aka 'int (*)(struct tvbuff *, struct _packet_info *, struct _proto_node *, void *)') [-Wincompatible-function-pointer-types]
 4965 |         register_dissector("btlmp", dissect_btbrlmp, proto_btbrlmp);
      |                                     ^~~~~~~~~~~~~~~
/usr/include/wireshark/epan/packet.h:579:83: note: passing argument to parameter 'dissector' here
  579 | WS_DLL_PUBLIC dissector_handle_t register_dissector(const char *name, dissector_t dissector, const int proto);
      |                                                                                   ^                                                               


I'm guessing dissector registration is part of the Wireshark API, and that it must have introduced a breaking change - requiring the function dissect_btbrlmp to have 4 parameters where it currently has 3.
I added an unused parameter (void *foo) to the function and, as far as I can tell, everything seems to be working.

The new function signature for dissect_btbrlmp() is:

	static int dissect_btbrlmp(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *foo)


Cheers,
Chris BC